### PR TITLE
Escape release tag messages

### DIFF
--- a/src/peltak/__init__.py
+++ b/src/peltak/__init__.py
@@ -17,5 +17,5 @@
 from __future__ import absolute_import, unicode_literals
 from os.path import abspath, dirname
 
-__version__ = '0.22'
+__version__ = '0.22.1'
 PKG_DIR = abspath(dirname(__file__))

--- a/src/peltak/core/git.py
+++ b/src/peltak/core/git.py
@@ -421,11 +421,11 @@ def tag(name, message, author=None, pretend=False):
     """
     cmd = (
         'git -c "user.name={author.name}" -c "user.email={author.email}" '
-        "tag -a '{name}' -m '{message}'"
+        'tag -a "{name}" -m "{message}"'
     ).format(
         author=author or latest_commit().author,
         name=name,
-        message=message,
+        message=message.replace('"', '\\"'),
     )
     if not pretend:
         shell.run(cmd)


### PR DESCRIPTION
(fix) Escape tag messages so they don't break the release tag command.