### PR TITLE
Release: v0.27.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: novopl/python36:ci-alpine
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:
@@ -63,7 +63,7 @@ jobs:
 
   release:
     docker:
-      - image: novopl/python36:ci-alpine
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:
@@ -88,7 +88,7 @@ jobs:
 
   docs:
     docker:
-      - image: novopl/python36:ci-alpine
+      - image: novopl/python36
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,8 @@ jobs:
             git checkout gh-pages
             cp -r docs/html/* ./
             git add .
-            git config user.email ${GIT_EMAIL}
-            git config user.name ${GIT_USER}
+            git config user.email "${GIT_EMAIL}"
+            git config user.name "${GIT_USER}"
             git commit -nm "Docs build #${CIRCLECI_BUILD_NUM}"
             git push --no-verify origin gh-pages
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import sphinx_rtd_theme
-
-
 project = u"peltak"
-copyright = u"2016-2018, Mateusz 'novo' Klos"
+copyright = u"2016-2021, Mateusz 'novo' Klos"
 author = u"Mateusz 'novo' Klos"
 
 
@@ -27,6 +24,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinxcontrib.plantuml',
+    'sphinx_autodoc_typehints',
 ]
 plantuml = 'java -jar {}'.format(repo_path('docs/bin/plantuml/plantuml.1.2019.9.jar'))
 plantuml_output_format = 'svg'
@@ -53,11 +51,37 @@ todo_include_todos = False
 intersphinx_mapping = {'https://docs.python.org/': None}
 
 default_role = 'any'
-pygments_style = 'monokai'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_theme = "sphinx_rtd_theme"
+# pygments_style = 'monokai'
 html_static_path = [repo_path('docs/_static')]
-html_style='css/overrides.css'
+html_theme = "sphinx_material"
+html_theme_options = {
+    # Set the name of the project to appear in the navigation.
+    'nav_title': 'peltak',
+    # Set you GA account ID to enable tracking
+    'google_analytics_account': 'UA-187740680-2',
+    # Specify a base_url used to generate sitemap.xml. If not
+    # specified, then no sitemap will be built.
+    'base_url': 'https://novopl.github.io/peltak',
+    # Set the color and the accent color
+    'color_primary': 'light-green',
+    'color_accent': 'amber',
+    # Set the repo location to get a badge with stats
+    'repo_url': 'https://github.com/novopl/peltak',
+    'repo_name': 'peltak',
+    'logo_icon': '&#x267E',
+    # Visible levels of the global TOC; -1 means unlimited
+    'globaltoc_depth': 2,
+    # If False, expand all TOC entries
+    'globaltoc_collapse': False,
+    # If True, show hidden TOC entries
+    'globaltoc_includehidden': True,
+}
+html_sidebars = {
+    "**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]
+}
+
+
+
 htmlhelp_basename = 'peltak'
 
 latex_elements = {}

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,6 +54,21 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 pytz = ">=2015.7"
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "certifi"
 version = "2020.12.5"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -95,6 +110,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
 toml = ["toml"]
+
+[[package]]
+name = "css-html-js-minify"
+version = "2.5.5"
+description = "CSS HTML JS Minifier"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "docutils"
@@ -214,6 +237,20 @@ description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "lxml"
+version = "4.6.2"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markupsafe"
@@ -420,6 +457,21 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-slugify"
+version = "4.0.1"
+description = "A Python Slugify application that handles Unicode"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+Unidecode = {version = ">=1.1.1", optional = true, markers = "extra == \"unidecode\""}
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
 name = "pytz"
 version = "2020.4"
 description = "World timezone definitions, modern and historical"
@@ -470,6 +522,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "soupsieve"
+version = "2.1"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "sphinx"
 version = "3.3.1"
 description = "Python documentation generator"
@@ -501,6 +561,39 @@ lint = ["flake8 (>=3.5.0)", "flake8-import-order", "mypy (>=0.790)", "docutils-s
 test = ["pytest", "pytest-cov", "html5lib", "typed-ast", "cython"]
 
 [[package]]
+name = "sphinx-autodoc-typehints"
+version = "1.11.1"
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+category = "dev"
+optional = false
+python-versions = ">=3.5.2"
+
+[package.dependencies]
+Sphinx = ">=3.0"
+
+[package.extras]
+test = ["pytest (>=3.1.0)", "typing-extensions (>=3.5)", "sphobjinv (>=2.0)", "Sphinx (>=3.2.0)", "dataclasses"]
+type_comments = ["typed-ast (>=1.4.0)"]
+
+[[package]]
+name = "sphinx-material"
+version = "0.0.32"
+description = "Material sphinx theme"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+beautifulsoup4 = "*"
+css-html-js-minify = "*"
+lxml = "*"
+python-slugify = {version = "*", extras = ["unidecode"]}
+sphinx = ">=2.0"
+
+[package.extras]
+dev = ["black (==19.10b0)"]
+
+[[package]]
 name = "sphinx-refdoc"
 version = "0.3.1"
 description = "Reference documentation generator for sphinx"
@@ -512,20 +605,6 @@ python-versions = "*"
 attrs = ">=16.3.0"
 click = ">=6.7"
 Sphinx = ">=1.5.1"
-
-[[package]]
-name = "sphinx-rtd-theme"
-version = "0.5.0"
-description = "Read the Docs theme for Sphinx"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["transifex-client", "sphinxcontrib-httpdomain", "bump2version"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -658,6 +737,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "unidecode"
+version = "1.1.2"
+description = "ASCII transliterations of Unicode text"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "urllib3"
 version = "1.26.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -693,7 +780,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "56e13037564634f48ac88513c3d1de82b49a35637281d38e8d639405320eb0c1"
+content-hash = "42301af35e1fcbd765529e2d2a605bfc64bc7526a82a1c2d5514c86556aed266"
 
 [metadata.files]
 alabaster = [
@@ -715,6 +802,11 @@ attrs = [
 babel = [
     {file = "Babel-2.9.0-py2.py3-none-any.whl", hash = "sha256:9d35c22fcc79893c3ecc85ac4a56cde1ecf3f19c540bba0922308a6c06ca6fa5"},
     {file = "Babel-2.9.0.tar.gz", hash = "sha256:da031ab54472314f210b0adcff1588ee5d1d1d0ba4dbd07b94dba82bde791e05"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.9.3-py2-none-any.whl", hash = "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35"},
+    {file = "beautifulsoup4-4.9.3-py3-none-any.whl", hash = "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"},
+    {file = "beautifulsoup4-4.9.3.tar.gz", hash = "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -767,6 +859,11 @@ coverage = [
     {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
     {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
     {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
+]
+css-html-js-minify = [
+    {file = "css-html-js-minify-2.5.5.zip", hash = "sha256:4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c"},
+    {file = "css_html_js_minify-2.5.5-py2.py3-none-any.whl", hash = "sha256:3da9d35ac0db8ca648c1b543e0e801d7ca0bab9e6bfd8418fee59d5ae001727a"},
+    {file = "css_html_js_minify-2.5.5-py3.6.egg", hash = "sha256:4704e04a0cd6dd56d61bbfa3bfffc630da6b2284be33519be0b456672e2a2438"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
@@ -830,6 +927,45 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
+]
+lxml = [
+    {file = "lxml-4.6.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a9d6bc8642e2c67db33f1247a77c53476f3a166e09067c0474facb045756087f"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:791394449e98243839fa822a637177dd42a95f4883ad3dec2a0ce6ac99fb0a9d"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:68a5d77e440df94011214b7db907ec8f19e439507a70c958f750c18d88f995d2"},
+    {file = "lxml-4.6.2-cp27-cp27m-win32.whl", hash = "sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e"},
+    {file = "lxml-4.6.2-cp27-cp27m-win_amd64.whl", hash = "sha256:69a63f83e88138ab7642d8f61418cf3180a4d8cd13995df87725cb8b893e950e"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:42ebca24ba2a21065fb546f3e6bd0c58c3fe9ac298f3a320147029a4850f51a2"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:535f067002b0fd1a4e5296a8f1bf88193080ff992a195e66964ef2a6cfec5388"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:366cb750140f221523fa062d641393092813b81e15d0e25d9f7c6025f910ee80"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:97db258793d193c7b62d4e2586c6ed98d51086e93f9a3af2b2034af01450a74b"},
+    {file = "lxml-4.6.2-cp35-cp35m-win32.whl", hash = "sha256:648914abafe67f11be7d93c1a546068f8eff3c5fa938e1f94509e4a5d682b2d8"},
+    {file = "lxml-4.6.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e751e77006da34643ab782e4a5cc21ea7b755551db202bc4d3a423b307db780"},
+    {file = "lxml-4.6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:681d75e1a38a69f1e64ab82fe4b1ed3fd758717bed735fb9aeaa124143f051af"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:127f76864468d6630e1b453d3ffbbd04b024c674f55cf0a30dc2595137892d37"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4fb85c447e288df535b17ebdebf0ec1cf3a3f1a8eba7e79169f4f37af43c6b98"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:5be4a2e212bb6aa045e37f7d48e3e1e4b6fd259882ed5a00786f82e8c37ce77d"},
+    {file = "lxml-4.6.2-cp36-cp36m-win32.whl", hash = "sha256:8c88b599e226994ad4db29d93bc149aa1aff3dc3a4355dd5757569ba78632bdf"},
+    {file = "lxml-4.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:6e4183800f16f3679076dfa8abf2db3083919d7e30764a069fb66b2b9eff9939"},
+    {file = "lxml-4.6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d8d3d4713f0c28bdc6c806a278d998546e8efc3498949e3ace6e117462ac0a5e"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8246f30ca34dc712ab07e51dc34fea883c00b7ccb0e614651e49da2c49a30711"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:923963e989ffbceaa210ac37afc9b906acebe945d2723e9679b643513837b089"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:1471cee35eba321827d7d53d104e7b8c593ea3ad376aa2df89533ce8e1b24a01"},
+    {file = "lxml-4.6.2-cp37-cp37m-win32.whl", hash = "sha256:2363c35637d2d9d6f26f60a208819e7eafc4305ce39dc1d5005eccc4593331c2"},
+    {file = "lxml-4.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc"},
+    {file = "lxml-4.6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0448576c148c129594d890265b1a83b9cd76fd1f0a6a04620753d9a6bcfd0a4d"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:60a20bfc3bd234d54d49c388950195d23a5583d4108e1a1d47c9eef8d8c042b3"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2e5cc908fe43fe1aa299e58046ad66981131a66aea3129aac7770c37f590a644"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:50c348995b47b5a4e330362cf39fc503b4a43b14a91c34c83b955e1805c8e308"},
+    {file = "lxml-4.6.2-cp38-cp38-win32.whl", hash = "sha256:94d55bd03d8671686e3f012577d9caa5421a07286dd351dfef64791cf7c6c505"},
+    {file = "lxml-4.6.2-cp38-cp38-win_amd64.whl", hash = "sha256:7a7669ff50f41225ca5d6ee0a1ec8413f3a0d8aa2b109f86d540887b7ec0d72a"},
+    {file = "lxml-4.6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e0bfe9bb028974a481410432dbe1b182e8191d5d40382e5b8ff39cdd2e5c5931"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6fd8d5903c2e53f49e99359b063df27fdf7acb89a52b6a12494208bf61345a03"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7e9eac1e526386df7c70ef253b792a0a12dd86d833b1d329e038c7a235dfceb5"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:7ee8af0b9f7de635c61cdd5b8534b76c52cd03536f29f51151b377f76e214a1a"},
+    {file = "lxml-4.6.2-cp39-cp39-win32.whl", hash = "sha256:2e6fd1b8acd005bd71e6c94f30c055594bbd0aa02ef51a22bbfa961ab63b2d75"},
+    {file = "lxml-4.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:535332fe9d00c3cd455bd3dd7d4bacab86e2d564bdf7606079160fa6251caacf"},
+    {file = "lxml-4.6.2.tar.gz", hash = "sha256:cd11c7e8d21af997ee8079037fff88f16fda188a9776eb4b81c7e4c9c0a7d7fc"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -955,6 +1091,9 @@ python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
+python-slugify = [
+    {file = "python-slugify-4.0.1.tar.gz", hash = "sha256:69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270"},
+]
 pytz = [
     {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
     {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
@@ -986,16 +1125,24 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
+soupsieve = [
+    {file = "soupsieve-2.1-py3-none-any.whl", hash = "sha256:4bb21a6ee4707bf43b61230e80740e71bfe56e55d1f1f50924b087bb2975c851"},
+    {file = "soupsieve-2.1.tar.gz", hash = "sha256:6dc52924dc0bc710a5d16794e6b3480b2c7c08b07729505feab2b2c16661ff6e"},
+]
 sphinx = [
     {file = "Sphinx-3.3.1-py3-none-any.whl", hash = "sha256:d4e59ad4ea55efbb3c05cde3bfc83bfc14f0c95aa95c3d75346fcce186a47960"},
     {file = "Sphinx-3.3.1.tar.gz", hash = "sha256:1e8d592225447104d1172be415bc2972bd1357e3e12fdc76edf2261105db4300"},
 ]
+sphinx-autodoc-typehints = [
+    {file = "sphinx-autodoc-typehints-1.11.1.tar.gz", hash = "sha256:244ba6d3e2fdb854622f643c7763d6f95b6886eba24bec28e86edf205e4ddb20"},
+    {file = "sphinx_autodoc_typehints-1.11.1-py3-none-any.whl", hash = "sha256:da049791d719f4c9813642496ee4764203e317f0697eb75446183fa2a68e3f77"},
+]
+sphinx-material = [
+    {file = "sphinx_material-0.0.32-py3-none-any.whl", hash = "sha256:dadc6669c37950b222b5dd8f621191b5a49bd567f9c0eecd8d92ea5ca4210162"},
+    {file = "sphinx_material-0.0.32.tar.gz", hash = "sha256:ec02825a1bbe8b662fe624c11b87f1cd8d40875439b5b18c38649cf3366201fa"},
+]
 sphinx-refdoc = [
     {file = "sphinx-refdoc-0.3.1.tar.gz", hash = "sha256:4f629412ae4f95c8074da77c6666370c61e29a4c19f168febe4ab6b0ba66edb1"},
-]
-sphinx-rtd-theme = [
-    {file = "sphinx_rtd_theme-0.5.0-py2.py3-none-any.whl", hash = "sha256:373413d0f82425aaa28fb288009bf0d0964711d347763af2f1b65cafcb028c82"},
-    {file = "sphinx_rtd_theme-0.5.0.tar.gz", hash = "sha256:22c795ba2832a169ca301cd0a083f7a434e09c538c70beb42782c073651b707d"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -1075,6 +1222,10 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+unidecode = [
+    {file = "Unidecode-1.1.2-py2.py3-none-any.whl", hash = "sha256:4c9d15d2f73eb0d2649a151c566901f80a030da1ccb0a2043352e1dbf647586b"},
+    {file = "Unidecode-1.1.2.tar.gz", hash = "sha256:a039f89014245e0cad8858976293e23501accc9ff5a7bdbc739a14a2b7b85cdc"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peltak"
-version = "0.27.0"
+version = "0.27.1"
 description = "A command line tool to help manage a project"
 readme = "README.rst"
 repository = "http://github.com/novopl/peltak"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,3 +145,12 @@ command_file = "ops/scripts/check.sh.j2"
     include = "*.py"
     use_gitignore = true
 
+[tool.peltak.scripts.pr-release]
+root_cli = true
+about = "Create PR for the current release branch"
+command = """
+gh pr create \
+    --repo novopl/peltak \
+    --title "Release: v$(peltak version --porcelain)" \
+    --body "$(peltak changelog)"
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,11 @@ pytest-cov = "~=2.10.1"
 pytest-sugar = "~=0.9.4"
 Sphinx = ">=3.3.1"
 sphinx-refdoc = "~=0.3.0"
-sphinx-rtd-theme = "~=0.2"
 sphinxcontrib-plantuml = "~=0.17.1"
 requests = "~=2.25.0"
 flake8 = "^3.8.4"
+sphinx-material = "^0.0.32"
+sphinx-autodoc-typehints = "^1.11.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/peltak/__init__.py
+++ b/src/peltak/__init__.py
@@ -16,5 +16,5 @@
 from os.path import abspath, dirname
 
 
-__version__ = '0.27.0'
+__version__ = '0.27.1'
 PKG_DIR = abspath(dirname(__file__))

--- a/src/peltak/extra/changelog/commands.py
+++ b/src/peltak/extra/changelog/commands.py
@@ -23,13 +23,43 @@ CLI definition.
 from peltak.commands import root_cli, click
 
 
-@root_cli.group('changelog', invoke_without_command=True)
+@root_cli.group(
+    'changelog',
+    invoke_without_command=True,
+    help=(
+        "Generate changelog from commit messages.\n"
+        "\n"
+        "This will go over all commits between the given git revisions and"
+        "extract all changelog data from them. If called without arguments "
+        "it will show all changelog entries since the last version tag."
+    )
+)
+@click.option(
+    '-s', '--start-rev',
+    help="Starting revision. Defaults to last version tag found"
+)
+@click.option(
+    '-e', '--end-rev',
+    help='End revision, defaults to HEAD',
+)
+@click.option(
+    '-t', '--title',
+    default=None,
+    help=(
+        'Changelog title.\n'
+        '\n'
+        'Will use the current project version if not given. Use empty string '
+        'to remove the title completely, ie `peltak changelog --title ""`'
+    ),
+)
 @click.pass_context
-def changelog_cli(ctx: click.Context) -> None:
+def changelog_cli(ctx: click.Context, start_rev: str, end_rev: str, title: str) -> None:
     """ Generate changelog from commit messages. """
     if ctx.invoked_subcommand:
         return
 
     from peltak.core import shell
     from . import logic
-    shell.cprint(logic.changelog())
+
+    changelog = logic.changelog(start_rev=start_rev, end_rev=end_rev, title=title)
+    shell.cprint(changelog)

--- a/src/peltak/extra/changelog/logic.py
+++ b/src/peltak/extra/changelog/logic.py
@@ -32,6 +32,7 @@ DEFAULT_TAGS = (
     {"tag": "change", "header": "Changes"},
     {"tag": "fix", "header": "Fixes"},
 )
+DEFAULT_TAG_FORMAT = '({tag})'
 
 
 @util.mark_experimental
@@ -81,7 +82,6 @@ def _get_commits_in_range(start_rev: Optional[str], end_rev: Optional[str]) -> L
 
 
 def _render_changelog(title: Optional[str], changelog_items: ChangelogItems) -> str:
-
     if title is None:
         # title is None if title parameter wasn't pass. To show empty title
         # you can use --title ''
@@ -128,8 +128,11 @@ def extract_changelog_items(text: str, tags: List[ChangelogTag]) -> Dict[str, Li
     The tagged items are usually features/changes/fixes but it can be configured
     through `pelconf.yaml`.
     """
-
-    patterns = {tag.header: tag_re(tag.tag) for tag in tags}
+    tag_format = conf.get("changelog.tag_format", DEFAULT_TAG_FORMAT)
+    patterns = {
+        tag.header: tag_re(tag_format.format(tag=tag.tag))
+        for tag in tags
+    }
     items: ChangelogItems = {tag.header: [] for tag in tags}
     curr_tag = None
     curr_text = ''
@@ -178,5 +181,5 @@ def tag_re(tag: str) -> Pattern:
     """
     return re.compile(
         # r'\(feature\) (?P<text>.*?\n\n)',
-        r'(- |\* |\s+)?\({tag}\) (?P<text>.*)'.format(tag=tag),
+        r'(- |\* |\s+)?{tag} (?P<text>.*)'.format(tag=re.escape(tag)),
     )

--- a/test/unit/extra/changelog/logic/test_extract_changelog_items.py
+++ b/test/unit/extra/changelog/logic/test_extract_changelog_items.py
@@ -3,6 +3,7 @@ import pytest
 
 from peltak.extra.changelog import logic
 from peltak.extra.changelog.types import ChangelogTag
+from peltak import testing
 
 
 @pytest.mark.parametrize('header,tag', [
@@ -10,6 +11,7 @@ from peltak.extra.changelog.types import ChangelogTag
     ('Changes', 'change'),
     ('Fixes', 'fix'),
 ])
+@testing.patch_pelconf({})
 def test_detects_each_tag(header, tag):
     desc = '\n'.join([
         '({tag}) This is my item'.format(tag=tag),
@@ -31,6 +33,7 @@ def test_detects_each_tag(header, tag):
     ('Changes', 'change'),
     ('Fixes', 'fix'),
 ])
+@testing.patch_pelconf({})
 def test_supports_dense_descriptions(header, tag):
     desc = '\n'.join([
         '({tag}) This is my item'.format(tag=tag),
@@ -54,6 +57,7 @@ def test_supports_dense_descriptions(header, tag):
     ('Changes', 'change'),
     ('Fixes', 'fix'),
 ])
+@testing.patch_pelconf({})
 def test_supports_loose_descriptions(header, tag):
     desc = '\n'.join([
         '',
@@ -74,6 +78,7 @@ def test_supports_loose_descriptions(header, tag):
     assert items[header][1] == 'This is my second item'
 
 
+@testing.patch_pelconf({})
 def test_supports_all_tags_used_together():
     desc = '\n'.join([
         '(fix) This is my fix',
@@ -99,6 +104,7 @@ def test_supports_all_tags_used_together():
     assert items['Fixes'][0] == 'This is my fix and it has multiple lines'
 
 
+@testing.patch_pelconf({})
 def test_ignores_non_tagged_text():
     desc = '\n'.join([
         'This is some text that should be gnored',

--- a/test/unit/extra/changelog/logic/test_extract_changelog_items.py
+++ b/test/unit/extra/changelog/logic/test_extract_changelog_items.py
@@ -119,3 +119,19 @@ def test_ignores_non_tagged_text():
 
     assert len(items['Features']) == 1
     assert items['Features'][0] == 'This is my feature'
+
+
+@testing.patch_pelconf({})
+def test_support_continuation_tags():
+    desc = '\n'.join([
+        '(feature) This is my item',
+        '',
+        '(_more) and it has a continuation tag.',
+    ])
+
+    items = logic.extract_changelog_items(desc, tags=[
+        ChangelogTag(header='Features', tag='feature'),
+    ])
+
+    assert len(items['Features']) == 1
+    assert items['Features'][0] == 'This is my item\nand it has a continuation tag.'


### PR DESCRIPTION
v0.27.1
========


Features
--------

- Support changelog tags in commit title
  And now it also supports continuation tags, so the changelog item in the
  title can easily be extended via commit description.
- You can now customize tag format recognized by `peltak changelog`. The
  default will still be `({tag})`  - parenthesis with tag name inside, but you
  can change it to whatever you wish. Setting it to `{tag}:` will allow you to
  use commitizen convention for example.
- Ability to get changelog for any revision range. From now on, the `peltak
  changelog` command accepts 2 new arguments `-s/—start-rev`, `-e/—end-rev` to
  specify the commit range we want the changelog for.
- From now on `peltak changelog` command supports `-t/—title` that allows you
  to set the title of the generated changelog. Not passing the command will
  result in the same behaviour as before: use the current project version as
  title. If you want to remove the title completely, you can pass an empty
  string: `peltak changelog -t ''` will do the trick.