### PR TITLE
Release: v0.28.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peltak"
-version = "0.28.4"
+version = "0.28.5"
 description = "A command line tool to help manage a project"
 readme = "README.rst"
 repository = "http://github.com/novopl/peltak"
@@ -55,6 +55,7 @@ peltak-changelog = {path = "plugins/peltak-changelog", develop = true}
 peltak-gitflow = {path = "plugins/peltak-gitflow", develop = true}
 peltak-pypi = {path = "plugins/peltak-pypi", develop = true }
 peltak-todos = {path = "plugins/peltak-todos", develop = true }
+
 
 
 

--- a/src/peltak/__init__.py
+++ b/src/peltak/__init__.py
@@ -16,5 +16,5 @@
 from os.path import abspath, dirname
 
 
-__version__ = '0.28.4'
+__version__ = '0.28.5'
 PKG_DIR = abspath(dirname(__file__))

--- a/src/peltak/core/conf.py
+++ b/src/peltak/core/conf.py
@@ -222,13 +222,19 @@ def _load_config(path: str) -> Config:
     python_paths = [cfg.proj_path(p) for p in cfg.get('python_paths', [])]
     sys.path[0:0] = [p for p in python_paths if p not in sys.path]
 
+    # Add scripts_dir to python paths so we can directly import all the python
+    # scripts that exist there.
+    scripts_dir = cfg.get_path('scripts_dir')
+    if scripts_dir and scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
     # TODO: src_dir is deprecated, use 'python_paths' config value instead.
     if cfg.has('src_dir'):
         sys.path.insert(0, cfg.get_path('src_dir'))
 
     for cmd in cfg.get('commands', []):
         try:
-            _import(cmd)
+            py_import(cmd)
         except ImportError as ex:
             log.err("Failed to load commands from <33>{}<31>: {}", cmd, ex)
 
@@ -287,6 +293,6 @@ def _discover_proj_config() -> Optional[str]:
     return None
 
 
-def _import(cmd: str) -> ModuleType:
+def py_import(cmd: str) -> ModuleType:
     """ Exists only so we can patch it in tests."""
     return __import__(cmd)   # nocov

--- a/src/peltak/core/scripts/loader.py
+++ b/src/peltak/core/scripts/loader.py
@@ -75,6 +75,9 @@ def _iter_script_files(scripts_dir: Path) -> Iterator[Path]:
             # be registered via ``pelconf.yaml``
             # TODO: Autoload python scripts found inside `scripts_dir`.
             yield dir_item
+        elif dir_item.name.endswith('.py'):
+            # Auto load python scripts in scripts_dir
+            conf.py_import(dir_item.stem)
 
     return results
 

--- a/test/unit/core/pelconf/test_Pelconf_from_file.py
+++ b/test/unit/core/pelconf/test_Pelconf_from_file.py
@@ -40,7 +40,7 @@ test_config = util.yaml_load(test_yaml)
 
 
 @patch('peltak.core.conf.open', mock_open(read_data=test_yaml))
-@patch('peltak.core.conf._import', Mock())
+@patch('peltak.core.conf.py_import', Mock())
 def test_properly_loads_all_config_variables():
     values = conf._load_from_file('pelconf.yaml')
 
@@ -48,7 +48,7 @@ def test_properly_loads_all_config_variables():
 
 
 @patch('peltak.core.conf.open', mock_open(read_data=test_yaml))
-@patch('peltak.core.conf._import')
+@patch('peltak.core.conf.py_import')
 def test_imports_commands(p_import):
     values = conf._load_from_file('pelconf.yaml')
 


### PR DESCRIPTION
v0.28.5
========


Features
--------

- Autoload python scripts from `scripts_dir`
  From now on, you don’t need to specify custom python scripts within your
  `pelconf.yaml`. They will be autoloaded if they are place along regular shell
  scripts. With this mechanism, we can actually get rid of the whole
  configuration bit in side `pelconf.yaml`. We could load plugins via one of
  the standard discovery methods and load projects scripts from the
  `scripts_dir`.